### PR TITLE
Bugfix/unblock destructor

### DIFF
--- a/artdaq-epics-plugin/MetricPlugins/epics_metric.cc
+++ b/artdaq-epics-plugin/MetricPlugins/epics_metric.cc
@@ -42,7 +42,7 @@ class EpicsMetric : public MetricPlugin
 private:
 	std::string prefix_;
 	std::unordered_map<std::string, chid> channels_;
-	bool running;
+	bool running_;
 
 	bool checkChannel_(const std::string& name)
 	{
@@ -104,7 +104,7 @@ public:
    * \param metric_name Name of this metric instance
    */
 	explicit EpicsMetric(fhicl::ParameterSet const& pset, std::string const& app_name, std::string const& metric_name)
-	    : MetricPlugin(pset, app_name, metric_name), prefix_(pset.get<std::string>("channel_name_prefix", "artdaq")), channels_(), running(0) {
+	    : MetricPlugin(pset, app_name, metric_name), prefix_(pset.get<std::string>("channel_name_prefix", "artdaq")), channels_(), running_(0) {
 		METLOG(TLVL_DEBUG + 30) << "EpicsMetric CONSTRUCTOR";
 	}
 
@@ -133,8 +133,8 @@ public:
 			}
 		}
 		channels_.clear();
-		if (running) ca_context_destroy();  // destroy blocks if the context is already gone/not running
-		running = false;
+		if (running_) ca_context_destroy();  // destroy blocks if the context is already gone/not running
+		running_ = false;
 	}
 
 	/**
@@ -142,7 +142,7 @@ public:
    */
 	void startMetrics_() override {
 		SEVCHK(ca_context_create(ca_enable_preemptive_callback), NULL);		
-		running = true;
+		running_ = true;
 	}
 
 	/**

--- a/artdaq-epics-plugin/MetricPlugins/epics_metric.cc
+++ b/artdaq-epics-plugin/MetricPlugins/epics_metric.cc
@@ -42,6 +42,7 @@ class EpicsMetric : public MetricPlugin
 private:
 	std::string prefix_;
 	std::unordered_map<std::string, chid> channels_;
+	bool running;
 
 	bool checkChannel_(const std::string& name)
 	{
@@ -103,7 +104,7 @@ public:
    * \param metric_name Name of this metric instance
    */
 	explicit EpicsMetric(fhicl::ParameterSet const& pset, std::string const& app_name, std::string const& metric_name)
-	    : MetricPlugin(pset, app_name, metric_name), prefix_(pset.get<std::string>("channel_name_prefix", "artdaq")), channels_() {
+	    : MetricPlugin(pset, app_name, metric_name), prefix_(pset.get<std::string>("channel_name_prefix", "artdaq")), channels_(), running(0) {
 		METLOG(TLVL_DEBUG + 30) << "EpicsMetric CONSTRUCTOR";
 	}
 
@@ -132,7 +133,8 @@ public:
 			}
 		}
 		channels_.clear();
-		ca_context_destroy();
+		if (running) ca_context_destroy();  // destroy blocks if the context is already gone/not running
+		running = false;
 	}
 
 	/**
@@ -140,6 +142,7 @@ public:
    */
 	void startMetrics_() override {
 		SEVCHK(ca_context_create(ca_enable_preemptive_callback), NULL);		
+		running = true;
 	}
 
 	/**


### PR DESCRIPTION
Guard the ca context from being destroyed if it is already gone, trying to destroy it again blocks the destructor (for me), which blocks otsdaq state transitions back to halted.